### PR TITLE
Refactor SharedExampleGroup to new Concerns module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Support for Ruby 1.9.3 is officially dropped.
 
 ### Concerns
 
-Added module RSpec::SleepingKingStudios::Examples::SharedExampleGroup as a mixin for defining scoped shared example groups. Extend into a module to define shared example groups scoped to that module (and automatically included in example groups when the module is included), or extend into an example group to allow aliasing shared example groups with alternate or more expressive names.
+Added module RSpec::SleepingKingStudios::Concerns::SharedExampleGroup as a mixin for defining scoped shared example groups. Extend into a module to define shared example groups scoped to that module (and automatically included in example groups when the module is included), or extend into an example group to allow aliasing shared example groups with alternate or more expressive names.
 
 ### Custom Examples
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ RSpec::SleepingKingStudios defines a few concerns that can be included in or ext
 
 ### Shared Example Groups
 
-    require 'rspec/sleeping_king_studios/examples/shared_example_group'
+    require 'rspec/sleeping_king_studios/concerns/shared_example_group'
 
     module MyCustomExamples
-      extend RSpec::SleepingKingStudios::Examples::SharedExampleGroup
+      extend RSpec::SleepingKingStudios::Concerns::SharedExampleGroup
 
       shared_examples 'has custom behavior' do
         # Define expectations here...
@@ -56,11 +56,11 @@ Utility functions for defining shared examples. If included in a module, any sha
 
 ### `::alias_shared_examples`
 
-Aliases a defined shared example group, allowing it to be accessed using a new name. The example group must be defined in the current context using `shared_examples`. The aliases must be defined before including the module into an example group, or they will not be available in the example group.
+(also `::alias_shared_context`) Aliases a defined shared example group, allowing it to be accessed using a new name. The example group must be defined in the current context using `shared_examples`. The aliases must be defined before including the module into an example group, or they will not be available in the example group.
 
 ### `::shared_examples`
 
-Defines a shared example group within the context of the current module. Unlike a top-level example group defined using RSpec#shared_examples, these examples are not globally available, and must be mixed into an example group by including the module. The shared examples must be defined before including the module, or they will not be available in the example group.
+(also `::shared_context`) Defines a shared example group within the context of the current module. Unlike a top-level example group defined using RSpec#shared_examples, these examples are not globally available, and must be mixed into an example group by including the module. The shared examples must be defined before including the module, or they will not be available in the example group.
 
 ## Custom Matchers
 
@@ -149,8 +149,11 @@ Now has additional chaining functionality to validate the number of arguments ac
 
 **How To Use:**
 
-    # With a variable number of arguments.
-    expect(instance).to respond_to(:foo).with(2..3).arguments.with_a_block
+    # With a block.
+    expect(instance).to respond_to(:foo).with_a_block.
+
+    # With a variable number of arguments and a block.
+    expect(instance).to respond_to(:foo).with(2..3).arguments.and_a_block
 
     # With keyword arguments.
     expect(instance).to respond_to(:foo).with(0, :bar, :baz)
@@ -158,7 +161,7 @@ Now has additional chaining functionality to validate the number of arguments ac
 **Chaining:**
 
 * **with:** Expects at most one Integer or Range argument, and zero or more Symbol arguments corresponding to optional keywords. Verifies that the method accepts that keyword, or has a variadic keyword of the form `**params`. As of 2.1.0 and required keywords, verifies that all required keywords are provided.
-* **with\_a\_block:** No parameters. Verifies that the method requires a block argument of the form `&my_argument`. _Important note:_ A negative result _does not_ mean the method cannot accept a block, merely that it does not require one. Also, _does not_ check whether the block is called or yielded.
+* **with\_a\_block:** (also `and_a_block`) No parameters. Verifies that the method requires a block argument of the form `&my_argument`. _Important note:_ A negative result _does not_ mean the method cannot accept a block, merely that it does not require one. Also, _does not_ check whether the block is called or yielded.
 
 ### Core
 

--- a/lib/rspec/sleeping_king_studios/concerns.rb
+++ b/lib/rspec/sleeping_king_studios/concerns.rb
@@ -1,0 +1,8 @@
+# lib/rspec/sleeping_king_studios/concerns.rb
+
+require 'rspec/sleeping_king_studios'
+
+module RSpec::SleepingKingStudios
+  # RSpec-related concerns to mix into classes or objects.
+  module Concerns; end
+end # module

--- a/lib/rspec/sleeping_king_studios/concerns/shared_example_group.rb
+++ b/lib/rspec/sleeping_king_studios/concerns/shared_example_group.rb
@@ -1,8 +1,25 @@
-# lib/rspec/sleeping_king_studios/examples/shared_example_group.rb
+# lib/rspec/sleeping_king_studios/concerns/shared_example_group.rb
 
-require 'rspec/sleeping_king_studios/examples'
+require 'rspec/sleeping_king_studios/concerns'
 
-module RSpec::SleepingKingStudios::Examples
+module RSpec::SleepingKingStudios::Concerns
+  # Methods for creating reusable shared example groups and shared contexts in
+  # a module that can be mixed into multiple RSpec example groups.
+  #
+  # @example
+  #   module MySharedExamples
+  #     extend Rspec::SleepingKingStudios::Concerns::SharedExampleGroup
+  #
+  #     shared_examples 'my examples' do
+  #       # Define shared examples here.
+  #     end # shared_examples
+  #   end # module
+  #
+  #   RSpec.describe MyObject do
+  #     include MySharedExamples
+  #
+  #     include_examples 'my examples'
+  #   end # describe
   module SharedExampleGroup
     # Aliases a defined shared example group, allowing it to be accessed using
     # a new name. The example group must be defined in the current context
@@ -14,11 +31,17 @@ module RSpec::SleepingKingStudios::Examples
     #   as.
     # @param [String] old_name The name under which the shared example group is
     #   currently defined.
+    #
+    # @raise ArgumentError If the referenced shared example group does not
+    #   exist.
     def alias_shared_examples new_name, old_name
       proc = shared_example_groups[self][old_name]
 
+      raise ArgumentError.new(%{Could not find shared examples "#{old_name}"}) if proc.nil?
+
       self.shared_examples new_name, &proc
     end # method alias_shared_examples
+    alias_method :alias_shared_context, :alias_shared_examples
 
     # @api private
     def included other
@@ -44,6 +67,7 @@ module RSpec::SleepingKingStudios::Examples
     def shared_examples name, *metadata_args, &block
       RSpec.world.shared_example_group_registry.add(self, name, *metadata_args, &block)
     end # method shared_examples
+    alias_method :shared_context, :shared_examples
 
     private
 

--- a/lib/rspec/sleeping_king_studios/examples/property_examples.rb
+++ b/lib/rspec/sleeping_king_studios/examples/property_examples.rb
@@ -1,13 +1,13 @@
 # lib/rspec/sleeping_king_studios/examples/property_examples.rb
 
+require 'rspec/sleeping_king_studios/concerns/shared_example_group'
 require 'rspec/sleeping_king_studios/examples'
-require 'rspec/sleeping_king_studios/examples/shared_example_group'
 require 'rspec/sleeping_king_studios/matchers/core/have_reader'
 require 'rspec/sleeping_king_studios/matchers/core/have_writer'
 require 'sleeping_king_studios/tools/object_tools'
 
 module RSpec::SleepingKingStudios::Examples::PropertyExamples
-  extend RSpec::SleepingKingStudios::Examples::SharedExampleGroup
+  extend RSpec::SleepingKingStudios::Concerns::SharedExampleGroup
 
   UNDEFINED_PROPERTY_EXPECTATION = Object.new.freeze
 

--- a/lib/rspec/sleeping_king_studios/examples/rspec_matcher_examples.rb
+++ b/lib/rspec/sleeping_king_studios/examples/rspec_matcher_examples.rb
@@ -1,11 +1,11 @@
 # lib/rspec/sleeping_king_studios/examples/rspec_matcher_examples.rb
 
+require 'rspec/sleeping_king_studios/concerns/shared_example_group'
 require 'rspec/sleeping_king_studios/examples'
-require 'rspec/sleeping_king_studios/examples/shared_example_group'
 require 'rspec/sleeping_king_studios/matchers/base_matcher'
 
 module RSpec::SleepingKingStudios::Examples::RSpecMatcherExamples
-  extend RSpec::SleepingKingStudios::Examples::SharedExampleGroup
+  extend RSpec::SleepingKingStudios::Concerns::SharedExampleGroup
 
   shared_examples 'passes with a positive expectation' do
     let(:matcher_being_examined) { defined?(instance) ? instance : subject }

--- a/lib/rspec/sleeping_king_studios/matchers/built_in/respond_to.rb
+++ b/lib/rspec/sleeping_king_studios/matchers/built_in/respond_to.rb
@@ -65,6 +65,7 @@ module RSpec::SleepingKingStudios::Matchers::BuiltIn
       @expected_block = true
       self
     end # method with_a_block
+    alias_method :and_a_block, :with_a_block
 
     # @see BaseMatcher#failure_message
     def failure_message

--- a/spec/rspec/sleeping_king_studios/concerns/shared_example_group_spec.rb
+++ b/spec/rspec/sleeping_king_studios/concerns/shared_example_group_spec.rb
@@ -1,0 +1,140 @@
+# spec/rspec/sleeping_king_studios/concerns/shared_example_group_spec.rb
+
+require 'rspec/sleeping_king_studios/spec_helper'
+
+require 'rspec/sleeping_king_studios/concerns/shared_example_group'
+require 'rspec/sleeping_king_studios/matchers/built_in/respond_to'
+
+RSpec.describe RSpec::SleepingKingStudios::Concerns::SharedExampleGroup do
+  shared_examples 'with a defined example group' do
+    before(:each) do
+      instance.shared_examples('defined examples') {}
+    end # before each
+  end # shared examples
+
+  let(:instance)       { Module.new.extend described_class }
+  let(:registry)       { RSpec.world.shared_example_group_registry }
+  let(:example_groups) { registry.send :shared_example_groups }
+
+  def expect_to_define_example_group object, name
+    expect(example_groups[object]).to be_a Hash
+    expect(example_groups[object][name]).to be_a Proc
+  end # method expect_to_define_example_group
+
+  describe '#alias_shared_context' do
+    let(:context_name) { 'shared context' }
+
+    it { expect(instance).to respond_to(:alias_shared_context).with(2).arguments }
+
+    context 'with a defined example group' do
+      include_examples 'with a defined example group'
+
+      it 'defines a shared example group' do
+        instance.alias_shared_context(context_name, 'defined examples')
+
+        expect_to_define_example_group(instance, context_name)
+        expect_to_define_example_group(instance, 'defined examples')
+      end # it
+    end # context
+
+    context 'with an undefined example group' do
+      it 'raises an error' do
+        expect {
+          instance.alias_shared_context(context_name, 'defined examples')
+        }.to raise_error ArgumentError, %{Could not find shared examples "defined examples"}
+      end # it
+    end # context
+  end # describe
+
+  describe '#alias_shared_examples' do
+    let(:examples_name) { 'shared examples' }
+
+    it { expect(instance).to respond_to(:alias_shared_examples).with(2).arguments }
+
+    context 'with a defined example group' do
+      include_examples 'with a defined example group'
+
+      it 'defines a shared example group' do
+        instance.alias_shared_examples(examples_name, 'defined examples')
+
+        expect_to_define_example_group(instance, examples_name)
+        expect_to_define_example_group(instance, 'defined examples')
+      end # it
+    end # context
+
+    context 'with an undefined example group' do
+      it 'raises an error' do
+        expect {
+          instance.alias_shared_examples(examples_name, 'defined examples')
+        }.to raise_error ArgumentError, %{Could not find shared examples "defined examples"}
+      end # it
+    end # context
+  end # describe
+
+  describe '#included' do
+    include_examples 'with a defined example group'
+
+    let!(:object) do
+      Module.new.send :include, instance
+    end # let
+
+    it 'defines the shared example groups on the module' do
+      expect(example_groups[object]).to be_a Hash
+      expect(example_groups[object]['defined examples']).to be_a Proc
+    end # it
+  end # describe
+
+  describe '#shared_context' do
+    let(:examples_name) { 'shared context' }
+
+    it { expect(instance).to respond_to(:shared_context).with(1..9001).arguments.and_a_block }
+
+    it 'defines a shared example group' do
+      expect(registry).to receive(:add).with(instance, examples_name, :key => :value).and_call_original
+
+      instance.shared_context(examples_name, :key => :value) {}
+
+      expect_to_define_example_group(instance, examples_name)
+    end # it
+
+    context 'with a shared example group defined' do
+      include_examples 'with a defined example group'
+
+      it 'defines a shared example group' do
+        expect(registry).to receive(:add).with(instance, examples_name, :key => :value).and_call_original
+
+        instance.shared_context(examples_name, :key => :value) {}
+
+        expect_to_define_example_group(instance, examples_name)
+        expect_to_define_example_group(instance, 'defined examples')
+      end # it
+    end # context
+  end # describe
+
+  describe '#shared_examples' do
+    let(:examples_name) { 'shared examples' }
+
+    it { expect(instance).to respond_to(:shared_examples).with(1..9001).arguments.and_a_block }
+
+    it 'defines a shared example group' do
+      expect(registry).to receive(:add).with(instance, examples_name, :key => :value).and_call_original
+
+      instance.shared_examples(examples_name, :key => :value) {}
+
+      expect_to_define_example_group(instance, examples_name)
+    end # it
+
+    context 'with a shared example group defined' do
+      include_examples 'with a defined example group'
+
+      it 'defines a shared example group' do
+        expect(registry).to receive(:add).with(instance, examples_name, :key => :value).and_call_original
+
+        instance.shared_examples(examples_name, :key => :value) {}
+
+        expect_to_define_example_group(instance, examples_name)
+        expect_to_define_example_group(instance, 'defined examples')
+      end # it
+    end # context
+  end # describe
+end # describe

--- a/spec/rspec/sleeping_king_studios/matchers/built_in/respond_to_spec.rb
+++ b/spec/rspec/sleeping_king_studios/matchers/built_in/respond_to_spec.rb
@@ -30,6 +30,11 @@ describe RSpec::SleepingKingStudios::Matchers::BuiltIn::RespondToMatcher do
     it { expect(instance.with_a_block).to be instance }
   end # describe
 
+  describe '#and_a_block' do
+    it { expect(instance).to respond_to(:and_a_block).with(0).arguments }
+    it { expect(instance.and_a_block).to be instance }
+  end # describe
+
   <<-SCENARIOS
     When there is no matching method,
       Evaluates to false with should message "to respond to".


### PR DESCRIPTION
- Add #alias_shared_context and #shared_context aliases.
- Alias RespondTo#with_a_block to #and_a_block.

Current spec status:
- 2.0: 427 examples, 0 failures in 0.12451 seconds.
- 2.1: 492 examples, 0 failures in 0.11104 seconds.
