### PR TITLE
Fix keyword splatting for focused and wrapped example groups.

### DIFF
--- a/lib/rspec/sleeping_king_studios/concerns/focus_examples.rb
+++ b/lib/rspec/sleeping_king_studios/concerns/focus_examples.rb
@@ -27,7 +27,11 @@ module RSpec::SleepingKingStudios::Concerns
     #   automatically focus such groups.
     def finclude_examples name, *args, **kwargs, &block
       fdescribe '(focused)' do
-        include_examples name, *args, **kwargs, &block
+        if kwargs.empty?
+          include_examples name, *args, &block
+        else
+          include_examples name, *args, **kwargs, &block
+        end # if-else
       end # describe
     end # method wrap_examples
     alias_method :finclude_context, :finclude_examples
@@ -54,7 +58,11 @@ module RSpec::SleepingKingStudios::Concerns
     # groups.
     def xinclude_examples name, *args, **kwargs, &block
       xdescribe '(focused)' do
-        include_examples name, *args, **kwargs, &block
+        if kwargs.empty?
+          include_examples name, *args, &block
+        else
+          include_examples name, *args, **kwargs, &block
+        end # if-else
       end # describe
     end # method xinclude_examples
     alias_method :xinclude_context, :xinclude_examples

--- a/lib/rspec/sleeping_king_studios/concerns/wrap_examples.rb
+++ b/lib/rspec/sleeping_king_studios/concerns/wrap_examples.rb
@@ -20,7 +20,11 @@ module RSpec::SleepingKingStudios::Concerns
     #   block, such as additional examples or memoized values.
     def wrap_examples name, *args, **kwargs, &block
       describe name do
-        include_examples name, *args, **kwargs
+        if kwargs.empty?
+          include_examples name, *args
+        else
+          include_examples name, *args, **kwargs
+        end # if-else
 
         instance_eval(&block) if block_given?
       end # describe
@@ -41,7 +45,11 @@ module RSpec::SleepingKingStudios::Concerns
     #   block, such as additional examples or memoized values.
     def fwrap_examples name, *args, **kwargs, &block
       fdescribe name do
-        include_examples name, *args, **kwargs
+        if kwargs.empty?
+          include_examples name, *args
+        else
+          include_examples name, *args, **kwargs
+        end # if-else
 
         instance_eval(&block) if block_given?
       end # describe
@@ -64,7 +72,11 @@ module RSpec::SleepingKingStudios::Concerns
     #   block, such as additional examples or memoized values.
     def xwrap_examples name, *args, **kwargs, &block
       xdescribe name do
-        include_examples name, *args, **kwargs
+        if kwargs.empty?
+          include_examples name, *args
+        else
+          include_examples name, *args, **kwargs
+        end # if-else
 
         instance_eval(&block) if block_given?
       end # describe

--- a/spec/rspec/sleeping_king_studios/concerns/focus_examples_spec.rb
+++ b/spec/rspec/sleeping_king_studios/concerns/focus_examples_spec.rb
@@ -12,13 +12,7 @@ RSpec.describe RSpec::SleepingKingStudios::Concerns::FocusExamples do
   end # let
 
   describe '#finclude_examples' do
-    let(:examples_name)  { 'focused examples' }
-    let(:example_args)   { %w(foo bar baz) }
-    let(:example_kwargs) { { :wibble => :wobble } }
-
-    def perform_action &block
-      instance.finclude_examples examples_name, *example_args, **example_kwargs, &block
-    end # method perform_action
+    let(:examples_name) { 'focused examples' }
 
     it { expect(instance).to respond_to(:finclude_examples).with_unlimited_arguments.and_arbitrary_keywords.and_a_block }
 
@@ -35,18 +29,67 @@ RSpec.describe RSpec::SleepingKingStudios::Concerns::FocusExamples do
       end # end
 
       it 'should raise an error' do
-        expect { perform_action }.to raise_error exception_class, exception_message
+        expect { instance.finclude_examples examples_name }.to raise_error exception_class, exception_message
       end # it
     end # context
 
     context 'with a defined shared example group' do
-      it 'should include the shared example group' do
-        expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs)
+      let(:example_args)   { %w(foo bar baz) }
+      let(:example_kwargs) { { :wibble => :wobble } }
 
-        perform_action
+      describe 'with no arguments' do
+        def perform_action &block
+          instance.finclude_examples examples_name
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name)
+
+          perform_action
+        end # it
+      end # describe
+
+      describe 'with many arguments' do
+        def perform_action &block
+          instance.finclude_examples examples_name, *example_args
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, *example_args)
+
+          perform_action
+        end # it
+      end # it
+
+      describe 'with many keywords' do
+        def perform_action &block
+          instance.finclude_examples examples_name, **example_kwargs
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, **example_kwargs)
+
+          perform_action
+        end # it
+      end # it
+
+      describe 'with many arguments and many keywords' do
+        def perform_action &block
+          instance.finclude_examples examples_name, *example_args, **example_kwargs
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs)
+
+          perform_action
+        end # it
       end # it
 
       describe 'with a block' do
+        def perform_action &block
+          instance.finclude_examples examples_name, *example_args, **example_kwargs, &block
+        end # method perform_action
+
         it 'should include the shared example group and evaluate the block' do
           expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs) do |&block|
             instance.examples_included = true
@@ -80,13 +123,7 @@ RSpec.describe RSpec::SleepingKingStudios::Concerns::FocusExamples do
   end # describe
 
   describe '#xinclude_examples' do
-    let(:examples_name)  { 'skipped examples' }
-    let(:example_args)   { %w(foo bar baz) }
-    let(:example_kwargs) { { :wibble => :wobble } }
-
-    def perform_action &block
-      instance.xinclude_examples examples_name, *example_args, **example_kwargs, &block
-    end # method perform_action
+    let(:examples_name) { 'skipped examples' }
 
     it { expect(instance).to respond_to(:xinclude_examples).with_unlimited_arguments.and_arbitrary_keywords.and_a_block }
 
@@ -103,18 +140,67 @@ RSpec.describe RSpec::SleepingKingStudios::Concerns::FocusExamples do
       end # end
 
       it 'should raise an error' do
-        expect { perform_action }.to raise_error exception_class, exception_message
+        expect { instance.xinclude_examples examples_name }.to raise_error exception_class, exception_message
       end # it
     end # context
 
     context 'with a defined shared example group' do
-      it 'should include the shared example group' do
-        expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs)
+      let(:example_args)   { %w(foo bar baz) }
+      let(:example_kwargs) { { :wibble => :wobble } }
 
-        perform_action
+      describe 'with no arguments' do
+        def perform_action &block
+          instance.xinclude_examples examples_name
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name)
+
+          perform_action
+        end # it
+      end # describe
+
+      describe 'with many arguments' do
+        def perform_action &block
+          instance.xinclude_examples examples_name, *example_args
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, *example_args)
+
+          perform_action
+        end # it
+      end # it
+
+      describe 'with many keywords' do
+        def perform_action &block
+          instance.xinclude_examples examples_name, **example_kwargs
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, **example_kwargs)
+
+          perform_action
+        end # it
+      end # it
+
+      describe 'with many arguments and many keywords' do
+        def perform_action &block
+          instance.xinclude_examples examples_name, *example_args, **example_kwargs
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs)
+
+          perform_action
+        end # it
       end # it
 
       describe 'with a block' do
+        def perform_action &block
+          instance.xinclude_examples examples_name, *example_args, **example_kwargs, &block
+        end # method perform_action
+
         it 'should include the shared example group and evaluate the block' do
           expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs) do |&block|
             instance.examples_included = true

--- a/spec/rspec/sleeping_king_studios/concerns/wrap_examples_spec.rb
+++ b/spec/rspec/sleeping_king_studios/concerns/wrap_examples_spec.rb
@@ -12,13 +12,7 @@ RSpec.describe RSpec::SleepingKingStudios::Concerns::WrapExamples do
   end # let
 
   describe '#fwrap_examples' do
-    let(:examples_name)  { 'focused examples' }
-    let(:example_args)   { %w(foo bar baz) }
-    let(:example_kwargs) { { :wibble => :wobble } }
-
-    def perform_action &block
-      instance.fwrap_examples examples_name, *example_args, **example_kwargs, &block
-    end # method perform_action
+    let(:examples_name) { 'focused examples' }
 
     it { expect(instance).to respond_to(:fwrap_context).with_unlimited_arguments.and_arbitrary_keywords.and_a_block }
 
@@ -35,18 +29,67 @@ RSpec.describe RSpec::SleepingKingStudios::Concerns::WrapExamples do
       end # end
 
       it 'should raise an error' do
-        expect { perform_action }.to raise_error exception_class, exception_message
+        expect { instance.fwrap_examples examples_name }.to raise_error exception_class, exception_message
       end # it
     end # context
 
     context 'with a defined shared example group' do
-      it 'should include the shared example group' do
-        expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs)
+      let(:example_kwargs) { { :wibble => :wobble } }
+      let(:example_args)   { %w(foo bar baz) }
 
-        perform_action
+      describe 'with no arguments' do
+        def perform_action &block
+          instance.fwrap_examples examples_name
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name)
+
+          perform_action
+        end # it
+      end # describe
+
+      describe 'with many arguments' do
+        def perform_action &block
+          instance.fwrap_examples examples_name, *example_args
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, *example_args)
+
+          perform_action
+        end # it
+      end # it
+
+      describe 'with many keywords' do
+        def perform_action &block
+          instance.fwrap_examples examples_name, **example_kwargs
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, **example_kwargs)
+
+          perform_action
+        end # it
+      end # it
+
+      describe 'with many arguments and many keywords' do
+        def perform_action &block
+          instance.fwrap_examples examples_name, *example_args, **example_kwargs
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs)
+
+          perform_action
+        end # it
       end # it
 
       describe 'with a block' do
+        def perform_action &block
+          instance.fwrap_examples examples_name, *example_args, **example_kwargs, &block
+        end # method perform_action
+
         it 'should include the shared example group and evaluate the block' do
           expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs) do
             instance.examples_included = true
@@ -78,13 +121,7 @@ RSpec.describe RSpec::SleepingKingStudios::Concerns::WrapExamples do
   end # describe
 
   describe '#xwrap_examples' do
-    let(:examples_name)  { 'skipped examples' }
-    let(:example_args)   { %w(foo bar baz) }
-    let(:example_kwargs) { { :wibble => :wobble } }
-
-    def perform_action &block
-      instance.xwrap_examples examples_name, *example_args, **example_kwargs, &block
-    end # method perform_action
+    let(:examples_name) { 'skipped examples' }
 
     it { expect(instance).to respond_to(:xwrap_context).with_unlimited_arguments.and_arbitrary_keywords.and_a_block }
 
@@ -101,18 +138,67 @@ RSpec.describe RSpec::SleepingKingStudios::Concerns::WrapExamples do
       end # end
 
       it 'should raise an error' do
-        expect { perform_action }.to raise_error exception_class, exception_message
+        expect { instance.xwrap_examples examples_name }.to raise_error exception_class, exception_message
       end # it
     end # context
 
     context 'with a defined shared example group' do
-      it 'should include the shared example group' do
-        expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs)
+      let(:example_args)   { %w(foo bar baz) }
+      let(:example_kwargs) { { :wibble => :wobble } }
 
-        perform_action
+      describe 'with no arguments' do
+        def perform_action &block
+          instance.xwrap_examples examples_name
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name)
+
+          perform_action
+        end # it
+      end # describe
+
+      describe 'with many arguments' do
+        def perform_action &block
+          instance.xwrap_examples examples_name, *example_args
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, *example_args)
+
+          perform_action
+        end # it
+      end # it
+
+      describe 'with many keywords' do
+        def perform_action &block
+          instance.xwrap_examples examples_name, **example_kwargs
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, **example_kwargs)
+
+          perform_action
+        end # it
+      end # it
+
+      describe 'with many arguments and many keywords' do
+        def perform_action &block
+          instance.xwrap_examples examples_name, *example_args, **example_kwargs
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs)
+
+          perform_action
+        end # it
       end # it
 
       describe 'with a block' do
+        def perform_action &block
+          instance.xwrap_examples examples_name, *example_args, **example_kwargs, &block
+        end # method perform_action
+
         it 'should include the shared example group and evaluate the block' do
           expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs) do
             instance.examples_included = true
@@ -145,12 +231,6 @@ RSpec.describe RSpec::SleepingKingStudios::Concerns::WrapExamples do
 
   describe '#wrap_examples' do
     let(:examples_name)  { 'defined examples' }
-    let(:example_args)   { %w(foo bar baz) }
-    let(:example_kwargs) { { :wibble => :wobble } }
-
-    def perform_action &block
-      instance.wrap_examples examples_name, *example_args, **example_kwargs, &block
-    end # method perform_action
 
     it { expect(instance).to respond_to(:wrap_context).with_unlimited_arguments.and_arbitrary_keywords.and_a_block }
 
@@ -167,18 +247,67 @@ RSpec.describe RSpec::SleepingKingStudios::Concerns::WrapExamples do
       end # end
 
       it 'should raise an error' do
-        expect { perform_action }.to raise_error exception_class, exception_message
+        expect { instance.wrap_examples examples_name }.to raise_error exception_class, exception_message
       end # it
     end # context
 
     context 'with a defined shared example group' do
-      it 'should include the shared example group' do
-        expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs)
+      let(:example_args)   { %w(foo bar baz) }
+      let(:example_kwargs) { { :wibble => :wobble } }
 
-        perform_action
+      describe 'with no arguments' do
+        def perform_action &block
+          instance.wrap_examples examples_name
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name)
+
+          perform_action
+        end # it
+      end # describe
+
+      describe 'with many arguments' do
+        def perform_action &block
+          instance.wrap_examples examples_name, *example_args
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, *example_args)
+
+          perform_action
+        end # it
+      end # it
+
+      describe 'with many keywords' do
+        def perform_action &block
+          instance.wrap_examples examples_name, **example_kwargs
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, **example_kwargs)
+
+          perform_action
+        end # it
+      end # it
+
+      describe 'with many arguments and many keywords' do
+        def perform_action &block
+          instance.wrap_examples examples_name, *example_args, **example_kwargs
+        end # method perform_action
+
+        it 'should include the shared example group' do
+          expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs)
+
+          perform_action
+        end # it
       end # it
 
       describe 'with a block' do
+        def perform_action &block
+          instance.wrap_examples examples_name, *example_args, **example_kwargs, &block
+        end # method perform_action
+
         it 'should include the shared example group and evaluate the block' do
           expect(instance).to receive(:include_examples).with(examples_name, *example_args, **example_kwargs) do
             instance.examples_included = true


### PR DESCRIPTION
Resolves an issue for example groups with optional arguments.