### PR TITLE
[FIX]: Fix issue with composable matchers passing a symbol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ gemfiles/*.lock
 /.rubocop.yml
 /.rubocop_todo.yml
 /tmp
+
+# Vim Swap files
+*.swp

--- a/lib/rspec/sleeping_king_studios/matchers/description.rb
+++ b/lib/rspec/sleeping_king_studios/matchers/description.rb
@@ -18,7 +18,7 @@ module RSpec::SleepingKingStudios::Matchers
     #
     # @return [String] the matcher description
     def description
-      desc = matcher_name
+      desc = matcher_name.to_s
 
       desc << format_expected_items
 


### PR DESCRIPTION
Issue with composable matchers passing the name of the
method as a symbol which is receiving an attempt to be
concatenated with the second part of the description
failing on `<<` not defined for Symbol

**Test Example**:
```ruby
it 'expect to have composable matcher' do
  expect(TestingClass)
    .to receive(:call)
    .with(id, a_hash_including(params))

  TestingClass.call(params)
end
```

**Error**:
```bash
NoMethodError:
 undefined method `<<' for :a_hash_including:Symbol
 Did you mean?  <
# /rspec-sleeping_king_studios-2.3.0/lib/rspec/sleeping_king_studios/matchers/description.rb:24:in `description'
```